### PR TITLE
Add missing #include to fix vc2decode test program compilation.

### DIFF
--- a/testprogs/vc2decode.cpp
+++ b/testprogs/vc2decode.cpp
@@ -31,6 +31,7 @@
 #include <stdint.h>
 #include <time.h>
 
+#include <stdexcept>
 #include <string>
 #include <list>
 


### PR DESCRIPTION
Here's a trivial compilation fix.

I rescind any and all rights to the change, you have permission to use it in any way you see fit.
