### PR TITLE
Do not sign-extend the qindex

### DIFF
--- a/vc2hqdecode/VC2Decoder.cpp
+++ b/vc2hqdecode/VC2Decoder.cpp
@@ -1005,7 +1005,7 @@ uint64_t VC2Decoder::SliceInput(char *_idata, int ilength, JobData **jobs) {
 						throw VC2DECODER_CODEROVERRUN;
 					}
 
-					job->coded_slices[n].qindex = (int)(*(idata++));
+					job->coded_slices[n].qindex = (int)(*((uint8_t *)idata++));
 					job->coded_slices[n].length[0] = (int)(*((uint8_t *)idata++))*mParams.slice_size_scalar;
 
 #ifdef DEBUG_OP_SLICESIZES
@@ -1087,7 +1087,7 @@ uint64_t VC2Decoder::SliceInput(char *_idata, int ilength, JobData **jobs) {
 						throw VC2DECODER_CODEROVERRUN;
 					}
 
-					job->coded_slices[n].qindex = (int)(*(idata++));
+					job->coded_slices[n].qindex = (int)(*((uint8_t *)idata++));
 					job->coded_slices[n].length[0] = (int)(*((uint8_t *)idata++))*mParams.slice_size_scalar;
 
 #ifdef DEBUG_OP_SLICESIZES


### PR DESCRIPTION
Prevent a crash from negative-indexing the matrices array.
